### PR TITLE
Fix helm chart service port

### DIFF
--- a/charts/ca-injector/Chart.yaml
+++ b/charts/ca-injector/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.0.1
+version: 0.0.2
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/ca-injector/templates/webhook.yaml
+++ b/charts/ca-injector/templates/webhook.yaml
@@ -23,4 +23,5 @@ webhooks:
       namespace: {{ .Release.Namespace }} 
       name: {{ include "ca-injector.fullname" . }}
       path: /pods
+      port: {{ .Values.service.port }}
 --- 

--- a/charts/ca-injector/values.yaml
+++ b/charts/ca-injector/values.yaml
@@ -38,7 +38,7 @@ securityContext: {}
 
 service:
   type: ClusterIP
-  port: 80
+  port: 443
 
 resources: {}
   # We usually recommend not to specify default resources and to leave this as a conscious


### PR DESCRIPTION
The default chart configuration was broken due to a port mismatch between the default webhook port (443) and the chart's default service port (80). The result is the webhook always fails because kubernetes could not contact the webhook service on default port 443.

Several fixes:
- Use port 443 by default for the webhook service to match the k8s default
- Specify the service port in the webhook configuration in case a non default port is specified in values